### PR TITLE
provide a way to find the bytes read from Buffer

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -309,7 +309,7 @@ Parser.prototype.addRawCode = function(ctx) {
 
   this.resolveReferences(ctx);
 
-  ctx.pushCode("return vars;");
+  ctx.pushCode("vars.__bytesRead = offset; return vars;");
 };
 
 Parser.prototype.addRawCodeEncode = function(ctx) {


### PR DESCRIPTION
This change could possibly be breaking. Another way to do it would be wrap the return value into another object.
```
return { bytesRead: offset, vars}
```
But that 100% would be a breaking change

This allows users to post parsing check the length of the input buffer agasint the number of bytes read from it.
Which can make it easier to point out bugs in the application.

---
I've another PR for this here: https://github.com/keichi/binary-parser/pull/86
But I like the encoding functionality that you've put together aswell.